### PR TITLE
feat: :sparkles: send email for account verification and request forg…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 *.rest
 /build
-/node_modules
+node_modules
+.vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "dotenv": "^16.0.1",
         "eslint": "^8.21.0",
         "express": "^4.18.1",
+        "handlebars": "^4.7.7",
         "helmet": "^5.1.1",
         "jsonwebtoken": "^8.5.1",
         "nodemailer": "^6.7.7",
@@ -2557,6 +2558,26 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "license": "MIT",
@@ -3400,6 +3421,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
@@ -4659,6 +4685,14 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
@@ -5167,6 +5201,18 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "dev": true,
@@ -5354,6 +5400,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -7311,6 +7362,18 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "requires": {
@@ -7886,6 +7949,11 @@
     },
     "negotiator": {
       "version": "0.6.3"
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node-addon-api": {
       "version": "3.2.1",
@@ -8765,6 +8833,11 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
     "split2": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
@@ -9063,6 +9136,12 @@
     "typescript": {
       "version": "4.7.4"
     },
+    "uglify-js": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+      "optional": true
+    },
     "undefsafe": {
       "version": "2.0.5",
       "dev": true
@@ -9197,6 +9276,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "dotenv": "^16.0.1",
     "eslint": "^8.21.0",
     "express": "^4.18.1",
+    "handlebars": "^4.7.7",
     "helmet": "^5.1.1",
     "jsonwebtoken": "^8.5.1",
     "nodemailer": "^6.7.7",

--- a/src/app.ts
+++ b/src/app.ts
@@ -34,11 +34,11 @@ class App {
 
     private initMiddleware() {
         this.app.use(helmet());
-        // this.app.use(cors({ credentials: true}));
+        this.app.use(cors({ origin: process.env.ORIGIN, credentials: true }));
         this.app.use(express.json());
         this.app.use(express.urlencoded({ extended: true }));
         this.app.use(Log);
-        this.app.use('/docs', swaggerUI.serve, swaggerUI.setup(SwaggerJsDoc));
+        this.app.use('/', swaggerUI.serve, swaggerUI.setup(SwaggerJsDoc));
     }
 
     private initAddress() {

--- a/src/auth/controller/auth.controller.ts
+++ b/src/auth/controller/auth.controller.ts
@@ -43,7 +43,7 @@ class AuthController implements BaseController {
             validationMiddleware(VerifyDTO, RequestTypes.BODY),
             this.requestVerifyHandler,
         );
-        this.router.post(
+        this.router.patch(
             '/forget-password',
             validationMiddleware(ForgetPasswordCompleteDTO, RequestTypes.BODY),
             this.forgetPassword,
@@ -260,7 +260,7 @@ class AuthController implements BaseController {
     /**
      * @openapi
      * '/forget-password':
-     *  post:
+     *  patch:
      *     tags:
      *     - /auth
      *     summary: Forget Password
@@ -430,7 +430,7 @@ class AuthController implements BaseController {
     /**
      * @openapi
      * '/logout':
-     *  post:
+     *  delete:
      *     tags:
      *     - /auth
      *     summary: Logout User
@@ -441,30 +441,8 @@ class AuthController implements BaseController {
      *           schema:
      *              $ref: '#/components/schemas/RefreshTokenRequest'
      *     responses:
-     *      200:
-     *        description: Success
-     *        content:
-     *          application/json:
-     *            schema:
-     *              $ref: '#/components/schemas/RefreshTokenResponse'
-     *      400:
-     *        description: Bad Request
-     *        content:
-     *          application/json:
-     *            schema:
-     *              $ref: '#/components/schemas/BadRequestResponse'
-     *      401:
-     *        description: Unauthorized
-     *        content:
-     *          application/json:
-     *            schema:
-     *              $ref: '#/components/schemas/UnauthorizedResponse'
-     *      500:
-     *        description: Internal Server Error
-     *        content:
-     *          application/json:
-     *            schema:
-     *              $ref: '#/components/schemas/InternalServerErrorResponse'
+     *      204:
+     *        description: No Content
      */
     private logoutHandler = async (
         request: RefreshTokenRequest,

--- a/src/common/config/mailer.ts
+++ b/src/common/config/mailer.ts
@@ -3,8 +3,8 @@ import nodemailer from 'nodemailer';
 const Mailer = nodemailer.createTransport({
     service: 'outlook',
     auth: {
-        user: 'deco-freons@outlook.com',
-        pass: 'naTrah-bopqeb-9bijxo',
+        user: process.env.MAILER_USER,
+        pass: process.env.MAILER_PASSWORD,
     },
 });
 

--- a/src/common/enum/email.enum.ts
+++ b/src/common/enum/email.enum.ts
@@ -1,0 +1,6 @@
+export enum EMAIL {
+    VERIFY = '/../../common/mail/verify.html',
+    VERIFY_SUBJECT = 'Verify your _ Account',
+    FORGET_PASSWORD = '/../../common/mail/forget-password.html',
+    FORGET_PASSWORD_SUBJECT = 'Forget Password Instructions for _',
+}

--- a/src/common/exception/internalError.exception.ts
+++ b/src/common/exception/internalError.exception.ts
@@ -19,7 +19,7 @@ import BaseException from './base.exception';
  */
 class InternalServerErrorException extends BaseException {
     constructor(message?: string) {
-        super(500, message ?? 'Internal Server Error');
+        super(500, `Internal Server Error. ${message}`);
     }
 }
 

--- a/src/common/mail/forget-password.html
+++ b/src/common/mail/forget-password.html
@@ -1,0 +1,97 @@
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Password Reset</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;700&display=swap');
+
+        * {
+            font-family: 'Nunito Sans', sans-serif;
+            box-sizing: border-box
+        }
+
+        body {
+            margin: 0;
+        }
+
+        .main {
+            background-color: #D9D9D9;
+            border: 1px solid #8E9093;
+            width: 80%;
+            height: 75%;
+            font-weight: bold;
+            padding: 52px 0;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: 20px;
+            text-align: center;
+        }
+
+        .link {
+            display: inline-block;
+            background-color: #0AA1DD;
+            color: #FFFFFF;
+            font-size: 20px;
+            border-radius: 10px;
+            padding: 15px 40px;
+            text-decoration: none;
+            margin-top: 83px;
+        }
+
+        .subtitle {
+            padding: 0 192px;
+            color: #404852;
+            font-size: 22px;
+            margin-top: 35px
+        }
+
+        .desc {
+            color: #8E9093;
+            font-size: 22px;
+            margin-top: 192px;
+            padding: 0 92px;
+        }
+
+        @media only screen and (max-width: 800px) {
+            .main {
+                width: 100%;
+
+            }
+
+            .link {
+                padding: 15px 30px;
+                font-size: 16px;
+            }
+
+            .subtitle {
+                padding: 0 40px;
+            }
+
+            .desc {
+                margin-top: 150px;
+                font-size: 16px;
+                padding: 0 45px;
+            }
+        }
+    </style>
+</head>
+
+<body style="width:100%;height:100%;padding-top: 15px;">
+    <img src="cid:logo" alt="Logo" style="display:block;width:130px;height:130px;margin-left:auto;margin-right:auto;">
+    <div class="main">
+        <h1 style="color:#404852;font-size:30px;">Password Reset</h1>
+
+        <h2 class="subtitle">If you’ve lost your password or wish to reset it, use
+            the link below</h2>
+        <a href="{{url}}" target="_blank" rel="noopener noreferrer" class="link">Reset your password</a>
+
+        <p class="desc">If you did not request a password reset, you can safely ignore this email. Only a person with
+            access tou your email can reset your account password.
+        </p>
+    </div>
+
+</body>
+
+</html>

--- a/src/common/mail/verify.html
+++ b/src/common/mail/verify.html
@@ -1,0 +1,81 @@
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Verify Your Email</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;700&display=swap');
+
+        * {
+            font-family: 'Nunito Sans', sans-serif;
+            box-sizing: border-box
+        }
+
+        body {
+            margin: 0;
+        }
+
+        .main {
+            background-color: #D9D9D9;
+            border: 1px solid #8E9093;
+            width: 80%;
+            height: 75%;
+            font-weight: bold;
+            padding: 63px 20px;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: 20px;
+            text-align: center;
+        }
+
+        .link {
+            display: inline-block;
+            background-color: #0AA1DD;
+            color: #FFFFFF;
+            font-size: 20px;
+            border-radius: 10px;
+            padding: 15px 40px;
+            text-decoration: none;
+            margin-top: 28px;
+        }
+
+        .text {
+            color: #8E9093;
+            font-size: 22px;
+            margin-top: 192px;
+        }
+
+        @media only screen and (max-width: 600px) {
+            .main {
+                width: 100%;
+            }
+
+            .link {
+                padding: 15px 30px;
+                font-size: 16px;
+            }
+
+            .text {
+                margin-top: 150px;
+                font-size: 16px;
+            }
+        }
+    </style>
+</head>
+
+<body style="width:100%;height:100%;padding-top: 15px;">
+    <img src="cid:logo" alt="Logo" style="display:block;width:130px;height:130px;margin-left:auto;margin-right:auto;">
+    <div class="main">
+        <h1 style="color:#404852;font-size:30px;">You're one click away...</h1>
+        <a href="{{url}}" target="_blank" rel="noopener noreferrer" class="link">Verify
+            your email
+            address</a>
+
+        <p class="text">You've received this email because
+        </p>
+    </div>
+
+</body>
+
+</html>

--- a/src/common/utils/fs.ts
+++ b/src/common/utils/fs.ts
@@ -1,0 +1,10 @@
+import {promises as fs} from 'fs';
+
+const FileSystem = {
+    ReadFile: async(path: string) => {
+        const file = await fs.readFile(path, 'utf-8');
+        return file;
+    }
+}
+
+export default FileSystem


### PR DESCRIPTION
### Background: 

Send email for account verification and when user request forget password. Fix several documentation issue.

### Additional Packages/Dependencies:
nodemailer
handlebars

### Changes:
- /common/enum/email.ts
- /common/utils/fs.ts
- /common/mail
- /auth/service

### How to Implement:
- [x] Install nodemailer and handlebars (for filesystem)
- [x] After generating the url, send email using the configured nodemailer