### PR TITLE
fix: :recycle: change nodemailer service to gmail

### DIFF
--- a/src/common/config/mailer.ts
+++ b/src/common/config/mailer.ts
@@ -1,7 +1,7 @@
 import nodemailer from 'nodemailer';
 
 const Mailer = nodemailer.createTransport({
-    service: 'outlook',
+    service: 'gmail',
     auth: {
         user: process.env.MAILER_USER,
         pass: process.env.MAILER_PASSWORD,


### PR DESCRIPTION
### Background: 
Change nodemailer service to gmail, outlook kept banning our account

### Additional Packages/Dependencies:
none

### Changes:
- /common/config/mailer.ts

### How to Implement:
- [x] Change from outlook to gmail